### PR TITLE
Corrects HN base URL to use HTTPS rather than HTTP

### DIFF
--- a/readme.textile
+++ b/readme.textile
@@ -96,7 +96,7 @@ nil
 user=> (in-ns 'tutorial.scrape1)
 nil
 tutorial.scrape1=> *base-url*
-"http://news.ycombinator.com/"
+"https://news.ycombinator.com/"
 </pre>
 
 The first line loads the file. Note that we need to specify that the *scrape1* file is to be found in the *tutorial* directory which is under the *src* directory of the repo. *src* is put onto the classpath by *lein* so we don't need to specify it. Also take care to note that we left off the *.clj* extension. Unlike many scripting languages, loading a file actually <i>compiles</i> it. Clojure is not interpreted.

--- a/src/tutorial/scrape1.clj
+++ b/src/tutorial/scrape1.clj
@@ -1,7 +1,7 @@
 (ns tutorial.scrape1
   (:require [net.cgrand.enlive-html :as html]))
 
-(def *base-url* "http://news.ycombinator.com/")
+(def *base-url* "https://news.ycombinator.com/")
 
 (defn fetch-url [url]
   (html/html-resource (java.net.URL. url)))

--- a/src/tutorial/scrape2.clj
+++ b/src/tutorial/scrape2.clj
@@ -1,7 +1,7 @@
 (ns tutorial.scrape2
   (:require [net.cgrand.enlive-html :as html]))
 
-(def *base-url* "http://news.ycombinator.com/")
+(def *base-url* "https://news.ycombinator.com/")
 
 (defn fetch-url [url]
   (html/html-resource (java.net.URL. url)))


### PR DESCRIPTION
HackerNews moved permanently from http://news.ycombinator.com to https://news.ycombinator.com. This commit fixes swannodette/enlive-tutorial#13.
