### PR TITLE
Update scrape1.clj

### DIFF
--- a/src/tutorial/scrape1.clj
+++ b/src/tutorial/scrape1.clj
@@ -1,7 +1,7 @@
 (ns tutorial.scrape1
   (:require [net.cgrand.enlive-html :as html]))
 
-(def *base-url* "http://news.ycombinator.com/")
+(def *base-url* "https://news.ycombinator.com/")
 
 (defn fetch-url [url]
   (html/html-resource (java.net.URL. url)))


### PR DESCRIPTION
Hacker news changed to https. With http the function fails to produce any results.
