### PR TITLE
Fixed broken link

### DIFF
--- a/readme.textile
+++ b/readme.textile
@@ -242,7 +242,7 @@ h2. Your Third Scrape - The New York Times
 
 Our third scrape tackles the New York Times whose front page structure is considerably more complicated than Hacker News. Now to be clear this not that useful since the New York Times provides a fairly comprehensive list of RSS feeds.
 
-Take a look at "*scrape3.clj*":blob/master/src/tutorial/scrape3.clj. This is a bit longer. Before we dive in let's see how it works. Start up the Clojure REPL if it's not already up and running.
+Take a look at "*scrape3.clj*":src/tutorial/scrape3.clj. This is a bit longer. Before we dive in let's see how it works. Start up the Clojure REPL if it's not already up and running.
 
 <pre class="console">
 tutorial.scrape2=> (load "scrape3")


### PR DESCRIPTION
The link to scrape3.clj was broken in readme.textile
