### PR TITLE
Some tweaks to the NYT scraping example

### DIFF
--- a/src/tutorial/scrape3.clj
+++ b/src/tutorial/scrape3.clj
@@ -19,6 +19,14 @@
 
 (def ^:dynamic *summary-selector* [html/root :> :.summary])
 
+(defn split-on-space [word]
+  "Splits a string on words"
+  (clojure.string/split word #"\s+"))
+
+(defn squish [line]
+  (str/triml (str/join " "
+     (split-on-space (str/replace line #"\n" " ")))))
+
 (defn fetch-url [url]
   (html/html-resource (java.net.URL. url)))
 
@@ -30,7 +38,7 @@
         byline   (first (html/select [node] *byline-selector*))
         summary  (first (html/select [node] *summary-selector*))
         result   (map html/text [headline byline summary])]
-    (zipmap [:headline :byline :summary] (map #(str/replace % #"\n" "") result))))
+    (zipmap [:headline :byline :summary] (map squish result))))
 
 (defn empty-story? [node]
   (every? (fn [[k v]] (= v "")) node))

--- a/src/tutorial/scrape3.clj
+++ b/src/tutorial/scrape3.clj
@@ -5,7 +5,7 @@
 (def ^:dynamic *base-url* "http://nytimes.com/")
 
 (def ^:dynamic *story-selector*
-     [[:div.story
+     [[:article.story
        (html/but :.advertisement)
        (html/but :.autosStory)
        (html/but :.adCreative)]])


### PR DESCRIPTION
If you don't mind, I made two tweaks to the NYT scraping tutorial:
- It was returning no articles because the NYT homepage changed markup to use `article` instead of `div` tags for story elements.
- There was a lot of excess whitespace within extracted fields. I have added some code to squish whitespace down, but I'm sure you could make it much better.

Anyhow, this is fun. I am learning Clojure so this has been a great tutorial!
