### PR TITLE
Make cgrand/moustache a git dependency instead of a clojars dependency.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,8 @@
 (defproject enlive-tutorial "0.1.0"
   :description "Enlive Tutorial"
+  :plugins [[lein-git-deps "0.0.1-SNAPSHOT"]]
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [enlive "1.1.1"]
-                 [ring "1.2.0"]
-                 [net.cgrand/moustache "1.1.0"]])
+                 [ring "1.2.0"]]
+  :git-dependencies [[github.com:cgrand/moustache.git]]
+  )


### PR DESCRIPTION
Addresses TLS error that occurs when installing dependencies, per #39.